### PR TITLE
Fix API module imports

### DIFF
--- a/bot/src/api/api.js
+++ b/bot/src/api/api.js
@@ -1,4 +1,7 @@
+// HTTP API для выдачи задач пользователям
 const express = require("express");
+const { listUserTasks } = require("../services/service");
+
 
 const app = express();
 app.get('/tasks', async (req, res) => {

--- a/bot/src/api/middleware.js
+++ b/bot/src/api/middleware.js
@@ -1,3 +1,4 @@
+// Middleware JWT для проверки доступа к API
 const jwt = require('jsonwebtoken');
 
 const secretKey = process.env.JWT_SECRET || 'your-secret-key';


### PR DESCRIPTION
## Summary
- fix missing `listUserTasks` import
- add Russian file descriptions for API modules

## Testing
- `node -c bot/src/api/api.js`
- `node -c bot/src/api/middleware.js`
- `npm test` *(fails: jest not found)*
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6852eafbcd908320848ce7da75189599