### PR TITLE
Fix admin Dockerfile yarn

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,5 +1,5 @@
 # Назначение файла: сборка панели администратора на Node.js.
-# Используются yarn, TypeScript и Prisma.
+# Используются Yarn Berry (v4), TypeScript и Prisma.
 FROM node:18
 
 WORKDIR /admin
@@ -10,7 +10,8 @@ ENV TZ="UTC"
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN yarn install --frozen-lockfile --production
+RUN corepack enable && corepack prepare yarn@stable --activate
+RUN yarn install --immutable --mode=skip-build
 COPY . .
 
 RUN npm i -g typescript


### PR DESCRIPTION
## Summary
- switch admin Dockerfile to Yarn Berry for compatibility

## Testing
- `npm ls`
- `yarn run build --verbose`
- `docker compose config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68530d13ec448320b9af30b7d707bd85