### PR TITLE
Добавлены БД в docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 BOT_TOKEN=your_bot_token
 CHAT_ID=your_chat_id
 JWT_SECRET=secret_key
-MONGODB_URI=mongodb+srv://user:pass@cluster.mongodb.net/dbname
+MONGODB_URI=mongodb://mongo_db:27017/adminjs
 R2_ENDPOINT=https://<account>.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=key
 R2_SECRET_ACCESS_KEY=secret

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@
 3. В переменную `CHAT_ID` запишите ID чата для уведомлений. Его можно узнать через бота `@userinfobot`.
 4. Запустите контейнеры:
    ```bash
-    docker-compose up --build
-    ```
-    Compose соберёт образы из `bot/Dockerfile` и `admin/Dockerfile`. Бот будет работать в Telegram, а интерфейс AdminJS откроется на `http://localhost:3000/admin`.
+   docker-compose up --build
+   ```
+   Compose соберёт образы из `bot/Dockerfile` и `admin/Dockerfile`, а также поднимет контейнеры MongoDB и Postgres.
+   Бот будет работать в Telegram, а интерфейс AdminJS откроется на `http://localhost:3000/admin`.
 
 ### Развёртывание на [Pella](https://www.pella.app)
 1. Подключите репозиторий к сервису и выберите проект.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     env_file:
       - .env
     restart: always
+    depends_on:
+      - mongo_db
   admin:
     build:
       context: ./admin
@@ -14,3 +16,28 @@ services:
     env_file:
       - .env
     restart: always
+    depends_on:
+      - mongo_db
+      - postgres_db
+  mongo_db:
+    container_name: adminjs-example-mongo
+    image: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_db_example_app:/data/db
+  postgres_db:
+    container_name: adminjs-example-postgres
+    image: postgres
+    environment:
+      - POSTGRES_DB=adminjs
+      - POSTGRES_USER=adminjs
+      - POSTGRES_PASSWORD=adminjs
+    ports:
+      - "5435:5432"
+    volumes:
+      - postgres_db_example_app:/var/lib/postgresql/data
+
+volumes:
+  mongo_db_example_app:
+  postgres_db_example_app:


### PR DESCRIPTION
## Summary
- расширен `docker-compose.yml` сервисами MongoDB и Postgres
- обновлён пример `.env` для локальных БД
- описан запуск контейнеров в README

## Testing
- `docker compose config` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68531095e1d48320a502cb7a9c85a240