### PR TITLE
Add Docker environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,17 @@
+# Назначение файла: CI для проверки Docker
+# Модули: docker compose config и docker compose build
+name: "Docker"
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Проверка docker-compose.yml
+        run: docker compose config
+      - name: Сборка образов
+        run: docker compose build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Назначение файла: единый контейнер для бота и панели
+# Модули: admin и bot
+FROM node:18
+WORKDIR /app
+
+# Установка зависимостей
+COPY bot/package*.json ./bot/
+COPY admin/package.json ./admin/
+COPY admin/yarn.lock ./admin/
+COPY admin/.yarnrc.yml ./admin/
+RUN cd admin && corepack enable && corepack prepare yarn@stable --activate && yarn install --immutable --mode=skip-build && cd .. && cd bot && npm install && cd ..
+
+# Копирование исходников
+COPY bot ./bot
+COPY admin ./admin
+
+# Сборка панели
+RUN cd admin && npx prisma generate && npm i -g typescript && yarn build && rm -rf src && cd ..
+
+EXPOSE 3000
+CMD sh -c 'node admin/dist/index.js & npm --prefix bot start'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
    Compose соберёт образы из `bot/Dockerfile` и `admin/Dockerfile`, а также поднимет контейнеры MongoDB и Postgres.
    Бот будет работать в Telegram, а интерфейс AdminJS откроется на `http://localhost:3000/admin`.
 
+При необходимости можно собрать единый образ из корневого `Dockerfile`:
+```bash
+docker build -t task-manager .
+docker run --env-file .env -p 3000:3000 task-manager
+```
+
 ### Развёртывание на [Pella](https://www.pella.app)
 1. Подключите репозиторий к сервису и выберите проект.
 2. Для каждого контейнера задайте рабочую директорию `bot` или `admin`.
@@ -68,3 +74,6 @@ project-root/
 
 ## Лицензия
 Проект распространяется под лицензией MIT.
+
+## CI с Docker
+Файл `.github/workflows/docker.yml` проверяет `docker-compose.yml` и собирает образы при каждом pull request.


### PR DESCRIPTION
## Summary
- add Dockerfile for combined bot and admin services
- document Docker build in README
- add CI to validate Docker compose

## Testing
- `docker compose config` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_b_68531369b08c83208af96ff6bd7f5e5e