### PR TITLE
Fix Mongo env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 BOT_TOKEN=your_bot_token
 CHAT_ID=your_chat_id
 JWT_SECRET=secret_key
-MONGODB_URI=mongodb://mongo_db:27017/adminjs
+MONGO_DATABASE_URL=mongodb://mongo_db:27017/adminjs
 R2_ENDPOINT=https://<account>.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=key
 R2_SECRET_ACCESS_KEY=secret

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
    git clone https://github.com/SoftwareBrothers/adminjs-example-app.git admin
    ```
 2. Скопируйте `.env.example` в `.env` и при необходимости измените значения.
+   Для подключения MongoDB укажите переменную `MONGO_DATABASE_URL`.
 3. В переменную `CHAT_ID` запишите ID чата для уведомлений. Его можно узнать через бота `@userinfobot`.
 4. Запустите контейнеры:
    ```bash

--- a/bot/src/db/model.js
+++ b/bot/src/db/model.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const mongoose = require('mongoose')
 
 if (process.env.NODE_ENV !== 'test') {
-  mongoose.connect(process.env.MONGODB_URI)
+  mongoose.connect(process.env.MONGO_DATABASE_URL)
 }
 
 const taskSchema = new mongoose.Schema({


### PR DESCRIPTION
## Summary
- unify mongo env variable name in bot and example
- mention MONGO_DATABASE_URL in README

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853140949008320ac16a9f461f3c04b