### PR TITLE
Require JWT secret

### DIFF
--- a/bot/src/api/middleware.js
+++ b/bot/src/api/middleware.js
@@ -1,7 +1,11 @@
-// Middleware JWT для проверки доступа к API
+// Middleware JWT для проверки доступа к API. Модуль: jsonwebtoken
 const jwt = require('jsonwebtoken');
 
-const secretKey = process.env.JWT_SECRET || 'your-secret-key';
+const secretKey = process.env.JWT_SECRET;
+if (!secretKey) {
+  console.error('Переменная JWT_SECRET не задана');
+  process.exit(1);
+}
 
 // Middleware to verify JWT token
 function verifyToken(req, res, next) {

--- a/bot/src/auth/auth.js
+++ b/bot/src/auth/auth.js
@@ -1,9 +1,13 @@
-// Проверка прав администратора и генерация JWT
+// Проверка прав администратора и генерация JWT. Модули: node-telegram-bot-api, jsonwebtoken
 require('dotenv').config()
 const Bot = require('node-telegram-bot-api')
 const jwt = require('jsonwebtoken')
 const bot = new Bot(process.env.BOT_TOKEN)
-const secretKey = process.env.JWT_SECRET || 'secret'
+const secretKey = process.env.JWT_SECRET
+if (!secretKey) {
+  console.error('Переменная JWT_SECRET не задана')
+  process.exit(1)
+}
 
 async function verifyAdmin (userId) {
   const admins = await bot.getChatAdministrators(process.env.CHAT_ID)


### PR DESCRIPTION
## Summary
- check for `JWT_SECRET` and exit if missing
- remove default secrets from auth and API middleware

## Testing
- `npm install`
- `npm test` *(fails: process.exit 1)*
- `node -e "require('./src/auth/auth.js')"` with env variables
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68546cf4d81c83209a93fca06ee041ac