### PR TITLE
Fix API default port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ R2_ACCESS_KEY_ID=key
 R2_SECRET_ACCESS_KEY=secret
 R2_BUCKET_NAME=bucket
 APP_URL=http://localhost:3000
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
    ```bash
    cp .env.example .env
    ```
-    Далее заполните переменные, например `MONGO_DATABASE_URL` и `APP_URL`.
+    Далее заполните переменные, например `MONGO_DATABASE_URL`, `APP_URL` и `PORT`.
 3. В переменную `CHAT_ID` запишите ID чата для уведомлений. Его можно узнать через бота `@userinfobot`.
 4. Запустите контейнеры:
    ```bash

--- a/bot/src/api/api.js
+++ b/bot/src/api/api.js
@@ -22,5 +22,6 @@ app.post('/tasks/:id/status', verifyToken, async (req, res) => {
   res.json({ status: 'ok' })
 })
 
-app.listen(process.env.PORT || 3001)
+// По умолчанию API слушает порт 3000
+app.listen(process.env.PORT || 3000)
 module.exports = app


### PR DESCRIPTION
## Summary
- use port 3000 for API by default and document PORT env var

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854707cd0c88320bce709bc45cf5785