### PR TITLE
Fix MongoDB connect handling

### DIFF
--- a/bot/src/db/model.js
+++ b/bot/src/db/model.js
@@ -1,9 +1,12 @@
-// Подключение к MongoDB и определение модели задач
+// Подключение к MongoDB и определение модели задач. Модули: dotenv, mongoose
 require('dotenv').config()
 const mongoose = require('mongoose')
 
 if (process.env.NODE_ENV !== 'test') {
-  mongoose.connect(process.env.MONGO_DATABASE_URL)
+  mongoose.connect(process.env.MONGO_DATABASE_URL).catch(e => {
+    console.error('Ошибка подключения к MongoDB:', e.message)
+    process.exit(1)
+  })
 }
 
 const taskSchema = new mongoose.Schema({


### PR DESCRIPTION
## Summary
- improve MongoDB connection logic in bot
- exit on DB connection failure

## Testing
- `npm test`
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68547efa3e50832080601b66f91358b4