### PR TITLE
Fix rate limit under proxies

### DIFF
--- a/bot/src/api/api.js
+++ b/bot/src/api/api.js
@@ -10,6 +10,8 @@ const { verifyToken, asyncHandler, errorHandler } = require('./middleware')
 ;(async () => {
   const { Task, Group, User } = require('../db/model')
   const app = express()
+  // доверяем прокси для правильного определения IP
+  app.set('trust proxy', 1)
   app.use(express.json())
 
   // Define rate limiter: maximum 100 requests per 15 minutes


### PR DESCRIPTION
## Summary
- доверяем обратным прокси в API для корректной работы express-rate-limit

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6856867aa9488320a78f0d107f29e563