### PR TITLE
Fix trust proxy

### DIFF
--- a/bot/src/api/api.js
+++ b/bot/src/api/api.js
@@ -10,8 +10,9 @@ const { verifyToken, asyncHandler, errorHandler } = require('./middleware')
 ;(async () => {
   const { Task, Group, User } = require('../db/model')
   const app = express()
-  // доверяем прокси для правильного определения IP
-  app.set('trust proxy', 1)
+  // доверяем первому прокси для корректной работы express-rate-limit
+  // и получения реального IP пользователя из заголовка X-Forwarded-For
+  app.enable('trust proxy')
   app.use(express.json())
 
   // Define rate limiter: maximum 100 requests per 15 minutes


### PR DESCRIPTION
## Summary
- enable trust proxy in API server

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6856941d4fac8320878d0f45dc8769d0