### PR TITLE
Исправлен экспорт переменных в backup_mongo_r2.sh

### DIFF
--- a/scripts/backup_mongo_r2.sh
+++ b/scripts/backup_mongo_r2.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 # Назначение: резервное копирование MongoDB в облачное хранилище R2.
-# Модули: mongodump, gzip, aws cli.
+# Модули: mongodump, gzip, aws cli. Используется set -a для экспорта
+# переменных из .env без явного перечисления.
 set -e
-if [ ! -f .env ]; then
+DIR=$(dirname "$0")/..
+if [ ! -f "$DIR/.env" ]; then
   echo ".env не найден" >&2
   exit 1
 fi
-export $(grep -v '^#' .env | xargs)
+set -a
+. "$DIR/.env"
+set +a
 TS=$(date +%Y-%m-%d_%H-%M-%S)
 FILE="mongo_$TS.archive.gz"
 mongodump --uri "$MONGO_DATABASE_URL" --archive | gzip > "$FILE"


### PR DESCRIPTION
## Summary
- задали путь к корню проекта в `backup_mongo_r2.sh`
- переменные из `.env` загружаются через `set -a`
- обновлено описание в начале файла

## Testing
- `bash -n scripts/backup_mongo_r2.sh`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_b_6856ea92291c832084f07c3fb1c6878a