### PR TITLE
Fix static path issues

### DIFF
--- a/bot/client/next.config.ts
+++ b/bot/client/next.config.ts
@@ -6,17 +6,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: process.env.IS_OUTPUT_EXPORT ? "export" : "standalone",
-  basePath: "/admin-one-react-tailwind",
-  async redirects() {
-    return [
-      {
-        source: "/",
-        destination: "/admin-one-react-tailwind",
-        basePath: false,
-        permanent: false,
-      },
-    ];
-  },
   images: {
     unoptimized: true,
     remotePatterns: [


### PR DESCRIPTION
## Summary
- remove basePath from the miniapp config to avoid 404s

## Testing
- `docker compose config` *(fails: env file missing)*

------
https://chatgpt.com/codex/tasks/task_b_6856ffa5d05083209f45a331a9113d48