### PR TITLE
Update crystallization tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,3 +103,4 @@ docker compose config
 - Для получения одной задачи добавлен маршрут `GET /api/tasks/:id`.
 - Добавлена CLI `crystallizationManager.ts` для оценки зрелости задач, команды описаны в README.
 - Сценарий `crystal:loop` запускает лупы кристаллизации для всего репозитория и повторяется, пока средний уровень не превысит 99%.
+- CLI поддерживает команды `update-attrs`, `list-diamonds`, `list-funcs`, `list-tasks`, `stats`, `init`, `sync` и `update-badge`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tailwind config синхронизирован с шаблоном TailAdmin 1.3, подключены шрифты Inter, Poppins и Roboto.
 - Цикл продолжается, пока средний уровень не достигнет 99%.
 - Добавлена система кристаллизации задач и CLI `crystallizationManager.ts`.
+- Реализованы команды `update-attrs`, `list-diamonds`, `list-funcs`, `list-tasks`, `stats`, `init`, `sync` и `update-badge`.
 - Унификация доступа к MongoDB через `bot/src/db/queries.js`.
 - Подключение к базе вынесено в `bot/src/db/connection.js` с пулом соединений.
 - Добавлена карта запросов `docs/db_request_map.md`.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,15 @@ npm run crystal:kpi -- --id AGMCS-002 --score 0.88 --notes "Улучшен те�
 npm run crystal:level -- --id AGMCS-002
 npm run crystal:core -- --principles "Итеративное улучшение,AI для ревью"
 npm run crystal:avg
+npm run crystal:list-diamonds
+npm run crystal:list-tasks
+npm run crystal:list-funcs
+npm run crystal:stats
 npm run crystal:loop
 ```
+Дополнительно есть команды `crystal:init` для создания шаблона `crystallization.json`,
+`crystal:update-badge` для обновления бейджа уровня и `crystal:sync` для
+синхронизации файла между репозиторием и IDE.
 
 Команда `crystal:loop` запускает единый цикл анализа и обновляет KPI всех задач.
 Скрипт повторяет проверки, пока средний уровень не превысит **99%**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,7 @@
 - Расширяем документацию по сценарию использования API.
 - Настроен workflow `release.yml` для автоматических GitHub Releases.
 - Внедрена система "кристаллизации" задач и CLI `crystallizationManager.ts`.
+- Добавлены команды `update-attrs`, `list-diamonds`, `list-funcs`, `list-tasks`, `stats`, `init`, `sync` и `update-badge`.
 - Добавлен маршрут `/api/tasks/:id` для получения одной задачи.
 - Добавлен шаблон pull request и файл CODEOWNERS.
 - Создан issue template `task.yml` для универсальных задач.

--- a/crystallizationManager.ts
+++ b/crystallizationManager.ts
@@ -1,121 +1,375 @@
-/**
- * Управление файлом crystallization.json и вывод CLI-команд.
- * Модули: fs для работы с файлом, yargs для CLI.
- */
 import fs from 'fs';
+import path from 'path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { pathToFileURL } from 'url';
 
-interface KPIEntry {
+type KPIDef = {
+  key: string;
+  title: string;
+  threshold: number;
+};
+
+type KPIEntry = {
   iteration: number;
   score: number;
-  notes?: string;
-}
+  [key: string]: number | boolean | string | undefined;
+  is_diamond?: boolean;
+};
 
-interface Task {
+type Task = {
   id: string;
   title: string;
-  status: string;
+  status?: string;
   iteration: number;
   kpi_history: KPIEntry[];
-  final_score: number;
+  final_score?: number;
   notes?: string;
-}
+  complexity?: string;
+  tags?: string[];
+};
 
-interface Data {
+type Data = {
   core_version: number;
   core_principles: string[];
   tasks: Task[];
-  kpi_definitions: string[];
+  kpi_definitions: KPIDef[];
+};
+
+const DATA_FILE = path.resolve(__dirname, 'crystallization.json');
+
+function loadData(): Data {
+  const raw = fs.readFileSync(DATA_FILE, 'utf-8');
+  return JSON.parse(raw) as Data;
 }
 
-export class Manager {
-  file: string;
-  data: Data;
-  constructor(file = 'crystallization.json') {
-    this.file = file;
-    this.data = JSON.parse(fs.readFileSync(this.file, 'utf-8')) as Data;
-  }
-  save() {
-    fs.writeFileSync(this.file, JSON.stringify(this.data, null, 2));
-  }
-  addTask(t: Task) {
-    this.data.tasks.push(t);
-    this.save();
-    console.log(`✅ Task ${t.id} added.`);
-  }
-  updateKPI(id: string, score: number, notes?: string) {
-    const task = this.data.tasks.find((x) => x.id === id);
-    if (!task) return console.log(`❌ Task ${id} not found`);
-    const iter = task.iteration + 1;
-    task.kpi_history.push({ iteration: iter, score, notes });
-    task.iteration = iter;
-    task.final_score = score;
-    this.save();
-    console.log(`✅ KPI updated: ${score}`);
-  }
-  level(id: string) {
-    const task = this.data.tasks.find((x) => x.id === id);
-    if (!task) return console.log(`❌ Task ${id} not found`);
-    console.log(`Level ${Math.round(task.final_score * 100)}%`);
-  }
-  updateCore(principles: string[], bump = true) {
-    if (bump) this.data.core_version += 1;
-    this.data.core_principles = principles;
-    this.save();
-    console.log('✅ Core updated');
-  }
-  average(): number {
-    const sum = this.data.tasks.reduce((a, t) => a + (t.final_score || 0), 0);
-    const avg = +(sum / this.data.tasks.length * 100).toFixed(1) || 0;
-    console.log(`Average: ${avg}%`);
-    return avg;
-  }
+function saveData(data: Data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
 }
 
-export function runCLI() {
-  const m = new Manager();
-  yargs(hideBin(process.argv))
-    .command('add-task', 'Добавить задачу', (y) => y
-      .option('id', { type: 'string', demandOption: true })
-      .option('title', { type: 'string', demandOption: true })
-      .option('status', { type: 'string', default: 'backlog' })
-      .option('iteration', { type: 'number', default: 0 })
-      .option('final_score', { type: 'number', default: 0 })
-      .option('notes', { type: 'string' }),
-      (argv) => {
-        m.addTask({
-          id: argv.id,
-          title: argv.title,
-          status: argv.status,
-          iteration: argv.iteration,
-          kpi_history: [],
-          final_score: argv.final_score,
-          notes: argv.notes,
-        });
-    })
-    .command('update-kpi', 'Обновить KPI', (y) => y
-      .option('id', { type: 'string', demandOption: true })
-      .option('score', { type: 'number', demandOption: true })
-      .option('notes', { type: 'string' }),
-      (argv) => {
-        m.updateKPI(argv.id, argv.score, argv.notes);
-    })
-    .command('level', 'Показать уровень задачи', (y) => y.option('id', { type: 'string', demandOption: true }),
-      (argv) => m.level(argv.id))
-    .command('update-core', 'Обновить принципы', (y) => y
-      .option('principles', { type: 'string', demandOption: true })
-      .option('versionIncrement', { type: 'boolean', default: true }),
-      (argv) => {
-        m.updateCore((argv.principles as string).split(','), argv.versionIncrement);
-    })
-    .command('average', 'Средний уровень', () => {}, () => m.average())
-    .demandCommand()
-    .help()
-    .parse();
+function calcScore(values: Record<string, number>, defs: KPIDef[]): number {
+  let sum = 0;
+  defs.forEach((def) => {
+    const v = values[def.key];
+    if (typeof v === 'number') {
+      if (def.key === 'bug_count' || def.key === 'change_failure_rate') {
+        sum += v <= def.threshold ? 1 : 0;
+      } else {
+        sum += v >= def.threshold ? 1 : 0;
+      }
+    }
+  });
+  return +(sum / defs.length).toFixed(2);
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  runCLI();
+function updateKPI(task: Task, values: Record<string, number>, defs: KPIDef[]) {
+  const iter = task.iteration + 1;
+  const isDiamond = defs.every((def) => {
+    const v = values[def.key];
+    if (typeof v !== 'number') return false;
+    if (def.key === 'bug_count' || def.key === 'change_failure_rate') {
+      return v <= def.threshold;
+    }
+    return v >= def.threshold;
+  });
+  const score = isDiamond ? 1.0 : calcScore(values, defs);
+  const entry: KPIEntry = {
+    iteration: iter,
+    score,
+    ...values,
+    is_diamond: isDiamond,
+  };
+  task.iteration = iter;
+  task.kpi_history.push(entry);
+  task.final_score = score;
+  if (isDiamond) task.status = 'diamond';
 }
+
+yargs(hideBin(process.argv))
+  .command(
+    'add-task',
+    'Add new task',
+    (y) =>
+      y
+        .option('id', { type: 'string', demandOption: true })
+        .option('title', { type: 'string', demandOption: true })
+        .option('complexity', { type: 'string' })
+        .option('tags', { type: 'string' }),
+    (argv) => {
+      const data = loadData();
+      if (data.tasks.find((t) => t.id === argv.id)) {
+        console.error('Task already exists');
+        return;
+      }
+      data.tasks.push({
+        id: String(argv.id),
+        title: String(argv.title),
+        status: 'backlog',
+        iteration: 0,
+        kpi_history: [],
+        complexity: argv.complexity ? String(argv.complexity) : undefined,
+        tags: argv.tags
+          ? String(argv.tags)
+              .split(',')
+              .map((t) => t.trim())
+          : undefined,
+      });
+      saveData(data);
+      console.log('Task added');
+    }
+  )
+  .command(
+    'update-kpi',
+    'Update KPI values for task',
+    (y) =>
+      y
+        .option('id', { type: 'string', demandOption: true })
+        .option('metrics', { type: 'string', demandOption: true }),
+    (argv) => {
+      const data = loadData();
+      const task = data.tasks.find((t) => t.id === argv.id);
+      if (!task) {
+        console.error('Task not found');
+        return;
+      }
+      let metrics: Record<string, number> = {};
+      try {
+        metrics = JSON.parse(String(argv.metrics));
+      } catch {
+        console.error('Invalid metrics JSON');
+        return;
+      }
+      updateKPI(task, metrics, data.kpi_definitions);
+      saveData(data);
+      console.log(
+        task.status === 'diamond'
+          ? '💎 Diamond achieved!'
+          : `Progressed to iteration ${task.iteration}.`
+      );
+    }
+  )
+  .command(
+    'update-attrs',
+    'Update task complexity and tags',
+    (y) =>
+      y
+        .option('id', { type: 'string', demandOption: true })
+        .option('complexity', { type: 'string' })
+        .option('tags', { type: 'string' }),
+    (argv) => {
+      const data = loadData();
+      const task = data.tasks.find((t) => t.id === argv.id);
+      if (!task) {
+        console.error('Task not found');
+        return;
+      }
+      if (argv.complexity) {
+        task.complexity = String(argv.complexity);
+      }
+      if (argv.tags) {
+        task.tags = String(argv.tags)
+          .split(',')
+          .map((t) => t.trim());
+      }
+      saveData(data);
+      console.log('Task attributes updated');
+    }
+  )
+  .command(
+    'level',
+    'Show crystallization level for task',
+    (y) => y.option('id', { type: 'string', demandOption: true }),
+    (argv) => {
+      const data = loadData();
+      const task = data.tasks.find((t) => t.id === argv.id);
+      if (!task) {
+        console.error('Task not found');
+        return;
+      }
+      console.log(task.final_score ?? '0');
+    }
+  )
+  .command(
+    'update-core',
+    'Update core principles',
+    (y) => y.option('principles', { type: 'string', demandOption: true }),
+    (argv) => {
+      const data = loadData();
+      data.core_principles = String(argv.principles)
+        .split(',')
+        .map((p) => p.trim());
+      data.core_version += 1;
+      saveData(data);
+      console.log('Core principles updated');
+    }
+  )
+  .command(
+    'average',
+    'Show average crystallization level',
+    () => {},
+    () => {
+      const data = loadData();
+      const scores = data.tasks.map((t) => t.final_score ?? 0);
+      const avg = scores.reduce((a, b) => a + b, 0) / (scores.length || 1);
+      console.log(avg.toFixed(2));
+    }
+  )
+  .command(
+    'list-diamonds',
+    'List all tasks in diamond state',
+    () => {},
+    () => {
+      const data = loadData();
+      const diamonds = data.tasks.filter((t) => t.status === 'diamond');
+      if (diamonds.length === 0) {
+        console.log('No diamond tasks');
+        return;
+      }
+      diamonds.forEach((t) => {
+        console.log(`${t.id}: ${t.title}`);
+      });
+    }
+  )
+  .command(
+    'list-funcs',
+    'Scan project functions and store the most common',
+    () => {},
+    async () => {
+      const root = path.resolve(__dirname);
+      const tsFiles: string[] = [];
+      const exclude = ['node_modules', '.git'];
+
+      function gather(dir: string) {
+        for (const file of fs.readdirSync(dir)) {
+          if (exclude.includes(file)) continue;
+          const full = path.join(dir, file);
+          const stat = fs.statSync(full);
+          if (stat.isDirectory()) {
+            gather(full);
+          } else if (full.endsWith('.ts')) {
+            tsFiles.push(full);
+          }
+        }
+      }
+
+      gather(root);
+
+      const cachePath = path.resolve(root, '.listfuncs_cache.json');
+      let cache: Record<
+        string,
+        { mtime: number; counts: Record<string, number> }
+      > = {};
+      if (fs.existsSync(cachePath)) {
+        try {
+          cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
+        } catch {
+          cache = {};
+        }
+      }
+
+      const counts: Record<string, number> = {};
+      const newCache: typeof cache = {};
+      const reg = /function\s+(\w+)|const\s+(\w+)\s*=\s*\(/g;
+
+      await Promise.all(
+        tsFiles.map(async (f) => {
+          const stat = fs.statSync(f);
+          const cached = cache[f];
+          if (cached && cached.mtime === stat.mtimeMs) {
+            Object.entries(cached.counts).forEach(([name, c]) => {
+              counts[name] = (counts[name] || 0) + c;
+            });
+            newCache[f] = cached;
+            return;
+          }
+
+          const content = await fs.promises.readFile(f, 'utf-8');
+          const fileCounts: Record<string, number> = {};
+          let m: RegExpExecArray | null;
+          while ((m = reg.exec(content))) {
+            const name = m[1] || m[2];
+            if (!name) continue;
+            fileCounts[name] = (fileCounts[name] || 0) + 1;
+            counts[name] = (counts[name] || 0) + 1;
+          }
+          newCache[f] = { mtime: stat.mtimeMs, counts: fileCounts };
+        })
+      );
+
+      fs.writeFileSync(cachePath, JSON.stringify(newCache, null, 2));
+
+      const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+
+      if (entries.length) {
+        const result = entries[0];
+        const resultPath = path.resolve(root, 'most_common_function.txt');
+        fs.writeFileSync(resultPath, `${result[0]}\n`);
+        console.log(`Most common function: ${result[0]} (${result[1]})`);
+        console.log(`Result saved to ${resultPath}`);
+      } else {
+        console.log('No functions found');
+      }
+    }
+  )
+  .command(
+    'list-tasks',
+    'List all tasks with statuses',
+    () => {},
+    () => {
+      const data = loadData();
+      if (data.tasks.length === 0) {
+        console.log('No tasks found');
+        return;
+      }
+      data.tasks.forEach((t) => {
+        console.log(`${t.id}: ${t.title} [${t.status ?? 'unknown'}]`);
+      });
+    }
+  )
+  .command(
+    'stats',
+    'Show summary statistics',
+    () => {},
+    () => {
+      const data = loadData();
+      const statusCounts: Record<string, number> = {};
+      data.tasks.forEach((t) => {
+        const status = t.status ?? 'unknown';
+        statusCounts[status] = (statusCounts[status] || 0) + 1;
+      });
+      const avg =
+        data.tasks.reduce((sum, t) => sum + (t.final_score ?? 0), 0) /
+        (data.tasks.length || 1);
+      console.log('Task status counts:');
+      Object.entries(statusCounts).forEach(([k, v]) =>
+        console.log(`  ${k}: ${v}`)
+      );
+      console.log(`Average score: ${avg.toFixed(2)}`);
+    }
+  )
+  .command(
+    'init',
+    'Initialize crystallization in current repo',
+    () => {},
+    () => {
+      const target = path.resolve(process.cwd(), 'crystallization.json');
+      if (fs.existsSync(target)) {
+        console.error('crystallization.json already exists');
+        return;
+      }
+      const template: Data = {
+        core_version: 1,
+        core_principles: ['Iterative improvement', 'KPI-driven development'],
+        tasks: [],
+        kpi_definitions: [
+          { key: 'cycle_time_days', title: 'Cycle Time (days)', threshold: 3 },
+          { key: 'code_coverage', title: 'Code Coverage', threshold: 0.8 },
+        ],
+      };
+      fs.writeFileSync(target, JSON.stringify(template, null, 2));
+      console.log('Initialized crystallization.json');
+    }
+  )
+  .demandCommand()
+  .help()
+  .strict()
+  .parse();

--- a/package.json
+++ b/package.json
@@ -3,12 +3,20 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "crystal:add": "ts-node crystallizationManager.ts add-task",
-    "crystal:kpi": "ts-node crystallizationManager.ts update-kpi",
-    "crystal:level": "ts-node crystallizationManager.ts level",
-    "crystal:core": "ts-node crystallizationManager.ts update-core",
-    "crystal:avg": "ts-node crystallizationManager.ts average",
-    "crystal:loop": "ts-node scripts/run_crystal_loops.ts"
+    "crystal:add": "ts-node-esm crystallizationManager.ts add-task",
+    "crystal:kpi": "ts-node-esm crystallizationManager.ts update-kpi",
+    "crystal:attrs": "ts-node-esm crystallizationManager.ts update-attrs",
+    "crystal:level": "ts-node-esm crystallizationManager.ts level",
+    "crystal:core": "ts-node-esm crystallizationManager.ts update-core",
+    "crystal:avg": "ts-node-esm crystallizationManager.ts average",
+    "crystal:init": "ts-node-esm crystallizationManager.ts init",
+    "crystal:list-diamonds": "ts-node-esm crystallizationManager.ts list-diamonds",
+    "crystal:list-funcs": "ts-node-esm crystallizationManager.ts list-funcs",
+    "crystal:list-tasks": "ts-node-esm crystallizationManager.ts list-tasks",
+    "crystal:stats": "ts-node-esm crystallizationManager.ts stats",
+    "crystal:update-badge": "ts-node-esm scripts/update_badge.ts",
+    "crystal:sync": "ts-node-esm scripts/sync_crystallization.ts",
+    "crystal:loop": "ts-node-esm scripts/run_crystal_loops.ts"
   },
   "dependencies": {
     "ts-node": "^10.9.1",

--- a/scripts/sync_crystallization.ts
+++ b/scripts/sync_crystallization.ts
@@ -1,0 +1,24 @@
+// Назначение: синхронизация файла crystallization.json с IDE
+
+import fs from 'fs';
+import path from 'path';
+
+const repoFile = path.resolve('crystallization.json');
+const ideDir = path.resolve('.vscode');
+const ideFile = path.join(ideDir, 'crystallization.json');
+
+if (!fs.existsSync(ideDir)) {
+  fs.mkdirSync(ideDir);
+}
+
+const repoStat = fs.statSync(repoFile).mtimeMs;
+const ideExists = fs.existsSync(ideFile);
+const ideStat = ideExists ? fs.statSync(ideFile).mtimeMs : 0;
+
+if (ideExists && ideStat > repoStat) {
+  fs.copyFileSync(ideFile, repoFile);
+  console.log('Repository crystallization.json updated from IDE');
+} else {
+  fs.copyFileSync(repoFile, ideFile);
+  console.log('IDE crystallization.json updated from repository');
+}

--- a/scripts/update_badge.ts
+++ b/scripts/update_badge.ts
@@ -1,0 +1,35 @@
+// Назначение: обновление бейджа кристаллизации
+
+import fs from 'fs';
+
+function calcAverage(file = 'crystallization.json'): number {
+  const data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  const scores: number[] = data.tasks.map(
+    (t: Record<string, unknown>) => (t.final_score as number | undefined) ?? 0
+  );
+  const avg = scores.reduce((a, b) => a + b, 0) / (scores.length || 1);
+  return +avg.toFixed(2);
+}
+
+function updateReadme(percent: number) {
+  const readmePath = 'README.md';
+  let text = fs.readFileSync(readmePath, 'utf-8');
+  text = text.replace(
+    /crystallization-\d+%25/,
+    `crystallization-${percent}%25`
+  );
+  text = text.replace(
+    /\*\*Current Level:\*\* \d+%/,
+    `**Current Level:** ${percent}%`
+  );
+  fs.writeFileSync(readmePath, text);
+  console.log(`README badge updated to ${percent}%`);
+}
+
+if (require.main === module) {
+  const avg = calcAverage();
+  const percent = Math.round(avg * 100);
+  updateReadme(percent);
+}
+
+export { calcAverage, updateReadme };


### PR DESCRIPTION
## Summary
- pull advanced Crystallization CLI from `crystallization-development`
- add new commands to `package.json`
- include scripts to sync state and update badge
- document new capabilities across README, ROADMAP and CHANGELOG
- clarify additional CLI options in AGENTS.md

## Testing
- `npm test --prefix bot`
- `npx eslint bot/src`
- `npm run lint --prefix bot/web`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_685998fb1d288320994c9feb4d5dcc0e