### PR TITLE
Implement Attachment Menu update script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ docker compose config
 - Для проверки текущего URL кнопки меню используйте скрипт `scripts/get_menu_button_url.js`.
   что позволяет избежать ошибки дублирования в MongoDB.
 - Для смены ссылки применяйте `scripts/set_menu_button_url.js`.
+- Attachment Menu обновляется скриптом `scripts/set_attachment_menu_url.js`, страница выбора задач расположена по пути `/menu`.
 - В `docs/telegram_bot_manual.md` приведён пример вывода этого скрипта при отсутствующих токенах.
 - Руководство дополнено описанием работы с BotFather и примером запроса `getMyCommands`.
 - Для компонентов страницы `tasks` используйте путь `../../_components/Section/*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Добавлен скрипт `scripts/get_menu_button_url.js` для получения URL кнопки меню.
 - В документации показан пример его вывода при стандартных переменных окружения.
 - Появился скрипт `scripts/set_menu_button_url.js` для установки URL кнопки меню.
+- Для Attachment Menu создана страница `/menu` и скрипт `scripts/set_attachment_menu_url.js`.
 - Команды `/assign_task`, `/upload_file` и `/edit_last` проверяют наличие обязательных параметров и сообщают об ошибке, если аргументы не переданы.
 - `/assign_task` позволяет выбрать пользователя через `KeyboardButton.requestUser` или группу через `KeyboardButton.requestChat`.
 - Добавлены тесты commandValidation.test.js, которые эмулируют вызовы этих команд без параметров.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 Среди маршрутов API теперь есть `GET /api/tasks/:id` для получения одной задачи.
 Также доступен скрипт `scripts/get_menu_button_url.js`, который выводит URL из кнопки меню или `/empty`, если используется поведение по умолчанию.
 Для установки новой ссылки используется `scripts/set_menu_button_url.js`.
+Для Attachment Menu создан скрипт `scripts/set_attachment_menu_url.js`, он указывает на страницу `/menu`.
 Таблица всех ответов бота приведена в `docs/bot_responses.md`.
 Пример результата со значениями из `.env.example`:
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -270,6 +270,7 @@
 Ошибка: request to https://api.telegram.org/botyour_bot_token/getChatMenuButton failed, reason:
 ```
 - Для обновления ссылки на приложение используется `scripts/set_menu_button_url.js`.
+- При включённом Attachment Menu URL обновляется командой `npm run menu:update`, страница выбора задач доступна по `/menu`.
 - Скрипт `scripts/setup_tdweb.sh` устанавливает TDWeb и копирует файлы в `bot/web/public/tdlib` для интеграции с telegram-react.
 - Поддержаны глубокие ссылки `/start`: `task_<id>` открывает задачу, а `invite_<departmentId>` добавляет пользователя в отдел.
 - В начало ключевых файлов добавлены строки с назначением: `docs/dashboard_tailadmin.md`, `docs/lighthouse_20250624.md`, `docs/lighthouse_20250626.md`, `bot/web/README.md`.

--- a/bot/web/src/App.tsx
+++ b/bot/web/src/App.tsx
@@ -16,6 +16,7 @@ const Logs = lazy(() => import("./pages/Logs"));
 const Profile = lazy(() => import("./pages/Profile"));
 const DashboardPage = lazy(() => import("./pages/DashboardPage"));
 const TelegramLogin = lazy(() => import("./pages/TelegramLogin"));
+const AttachmentMenu = lazy(() => import("./pages/AttachmentMenu"));
 import Sidebar from "./layouts/Sidebar";
 import Header from "./layouts/Header";
 import { SidebarProvider, useSidebar } from "./context/SidebarContext";
@@ -32,6 +33,7 @@ function Content() {
       <Suspense fallback={<div>Загрузка...</div>}>
         <Routes>
           <Route path="/login" element={<TelegramLogin />} />
+          <Route path="/menu" element={<AttachmentMenu />} />
           <Route
             path="/profile"
             element={

--- a/bot/web/src/pages/AttachmentMenu.tsx
+++ b/bot/web/src/pages/AttachmentMenu.tsx
@@ -1,0 +1,39 @@
+// Страница выбора задачи для Attachment Menu
+import React, { useEffect, useState } from 'react';
+import authFetch from '../utils/authFetch';
+
+interface Task {
+  _id: string;
+  title: string;
+}
+
+export default function AttachmentMenu() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    authFetch('/api/tasks?limit=10')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setTasks);
+  }, []);
+
+  function select(id: string) {
+    if (window.Telegram?.WebApp?.sendData) {
+      window.Telegram.WebApp.sendData(`task_selected:${id}`);
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lg mb-4">Выберите задачу</h1>
+      <ul>
+        {tasks.map(t => (
+          <li key={t._id} className="mb-2">
+            <button onClick={() => select(t._id)} className="text-blue-600 underline">
+              {t.title}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/docs/telegram_bot_manual.md
+++ b/docs/telegram_bot_manual.md
@@ -126,6 +126,15 @@ node scripts/set_menu_button_url.js
 ```
 Если задан `CHAT_ID`, кнопка обновится только в указанном чате.
 
+## Включение Attachment Menu
+1. В диалоге с [@BotFather](https://t.me/BotFather) выберите нужного бота.
+2. Откройте раздел *Attachment Menu* и включите `Enable Attachment Menu`.
+3. Страница выбора задачи расположена по пути `/menu` мини‑приложения.
+4. Обновите ссылку кнопки командой:
+```bash
+npm run menu:update
+```
+
 ## Типовые ошибки API
 Ниже приведён пример сообщения, которое возвращает Bot API:
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "crystal:stats": "ts-node --esm crystallizationManager.ts stats",
     "crystal:loop": "ts-node --esm scripts/run_crystal_loops.ts",
     "crystal:auto-update": "node --loader ts-node/esm scripts/auto_update_crystallizer.ts",
-    "test": "npm test --prefix bot"
+    "test": "npm test --prefix bot",
+    "menu:update": "node scripts/set_attachment_menu_url.js"
   },
   "dependencies": {
     "ts-node": "^10.9.1",

--- a/scripts/set_attachment_menu_url.js
+++ b/scripts/set_attachment_menu_url.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Скрипт установки URL для Attachment Menu Telegram
+import fetch from 'node-fetch';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const token = process.env.BOT_TOKEN;
+const base = process.env.APP_URL;
+
+if (!token) {
+  console.error('BOT_TOKEN не задан');
+  process.exit(1);
+}
+if (!base) {
+  console.error('APP_URL не задан');
+  process.exit(1);
+}
+if (!base.startsWith('https://')) {
+  console.error('APP_URL должен начинаться с https://');
+  process.exit(1);
+}
+
+const url = `${base.replace(/\/$/, '')}/menu`;
+const chatId = process.env.CHAT_ID;
+
+async function updateMenu() {
+  const params = {
+    menu_button: {
+      type: 'web_app',
+      text: 'Мои задачи',
+      web_app: { url }
+    }
+  };
+  if (chatId) params.chat_id = chatId;
+  const res = await fetch(`https://api.telegram.org/bot${token}/setChatMenuButton`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params)
+  });
+  const data = await res.json();
+  if (!data.ok) throw new Error(data.description);
+}
+
+updateMenu()
+  .then(() => console.log('Attachment Menu обновлено'))
+  .catch(err => {
+    console.error('Ошибка:', err.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add script to update the Telegram Attachment Menu
- create `/menu` page to select tasks
- document Attachment Menu setup
- mention new script and page in README, CHANGELOG, ROADMAP and AGENTS

## Testing
- `npm test --prefix bot`
- `npx eslint bot/src`
- `npm run lint --prefix bot/web`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_b_685fa32dd27083209666ad3054a04401