### PR TITLE
Fix TypeScript settings for CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,6 +254,7 @@ docker compose config
   в интерфейсе задачи.
 - В начало документации и README добавлены комментарии с назначением файлов, чтобы упростить навигацию.
 - В `tsconfig.json` путь `include` указывает на `crystallizationManager.ts`.
+- Для корректной работы CLI добавлены опции `moduleResolution: node` и `types: ['node']`.
 - `.env.example` дополнен комментариями и содержит все переменные из `bot/src/config.js`.
 - В комментариях к каждой переменной указано её назначение и источник значения.
 - В README указан контроль схем `APP_URL` и `MONGO_DATABASE_URL`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Добавлена команда `/help` с кратким описанием всех команд.
 - Мини‑приложение отправляет `sendData('task_created:<id>')`, бот
   обрабатывает `web_app_data` и подтверждает создание задачи.
+- В `tsconfig.json` добавлены `moduleResolution: node` и `types: ['node']`, что устранило ошибки компиляции `crystallizationManager.ts`.
 - Команда `/create_task` создаёт топик через `createForumTopic` и сохраняет `telegram_topic_id`, ссылка отображается в интерфейсе.
 - Списки задач в командах `/list_tasks` и `/list_all_tasks` оснащены inline-кнопками для отметки выполнения и удаления.
 - Из репозитория удалён архив free-react-tailwind-admin-dashboard-main.zip; ссылка на источник добавлена в README.

--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ npm run crystal:auto-update
 - Переключение светлой и тёмной темы теперь учитывает настройку браузера (Switching between light and dark theme now respects the browser's preference).
 - В index.html подключён отдельный скрипт `theme.js`, который выставляет класс `dark` до запуска React и не нарушает CSP.
 - В `tsconfig.json` обновлён путь `include` на `crystallizationManager.ts` для корректной компиляции CLI.
+- Добавлены настройки `moduleResolution: node` и `types: ['node']`, что устранило ошибки TypeScript при сборке CLI.
  - Перед сборкой Docker проверьте актуальность `bot/web/package-lock.json`, иначе `npm ci` завершится ошибкой.
  - Если файл повреждён или отсутствует, удалите его и выполните `npm --prefix bot/web install` для создания нового lock-файла.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -285,6 +285,7 @@
 - Поддержаны глубокие ссылки `/start`: `task_<id>` открывает задачу, а `invite_<departmentId>` добавляет пользователя в отдел.
 - В начало ключевых файлов добавлены строки с назначением: `docs/dashboard_tailadmin.md`, `docs/lighthouse_20250624.md`, `docs/lighthouse_20250626.md`, `bot/web/README.md`.
 - В `tsconfig.json` обновлён путь `include` на `crystallizationManager.ts`.
+- В этот файл также добавлены опции `moduleResolution: node` и `types: ['node']`, что позволило успешно компилировать CLI.
 - Мини-приложение теперь работает только в светлой теме, стили собираются с
   `autoprefixer` для кросс-браузерности.
 - При деплое проверяйте `VITE_BOT_USERNAME`, иначе Telegram Login выдаст ошибку `Username invalid`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
         "ts-node": "^10.9.1",
         "typescript": "^5.4.5",
         "yargs": "^17.7.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.7",
+        "@types/yargs": "^17.0.33"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -74,14 +78,30 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -330,8 +350,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
     "menu:update": "node scripts/set_attachment_menu_url.js"
   },
   "dependencies": {
+    "dotenv": "^16.4.7",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.5",
-    "yargs": "^17.7.2",
-    "dotenv": "^16.4.7"
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.7",
+    "@types/yargs": "^17.0.33"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "esnext",
     "strict": true,
     "esModuleInterop": true,
+    "moduleResolution": "node",
+    "types": ["node"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist"


### PR DESCRIPTION
## Summary
- add Node typings for crystallization CLI
- document new TypeScript options
- update docs with latest setup steps

## Testing
- `npm test --prefix bot`
- `npx eslint bot/src`
- `npm run lint --prefix bot/web`
- `docker compose config`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68600952c37c832093ea11b079203447