### PR TITLE
Update Railway example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ docker compose config
   `mongodb://` или `mongodb+srv://`, иначе приложение не подключится к базе.
 - При ошибке `502` на `/bot` не удаётся подключиться к MongoDB. Проверьте доступность DNS кластера и корректность `MONGO_DATABASE_URL`. Бот выполнит три попытки переподключения.
 - В Railway можно добавить плагин MongoDB; URL вставьте в `MONGO_DATABASE_URL`.
+- В качестве примера используется домен `mongodb-production-2083.up.railway.app:27017`.
 - `APP_URL` должен быть HTTPS, иначе Telegram отвергнет Web App ссылку.
 - Для запуска тестов также задавайте `APP_URL`, иначе Jest завершится ошибкой.
 - При указании `WEBHOOK_URL` бот запускается в режиме webhook и регистрирует URL через `setWebhook`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,3 +280,4 @@
   фронтенда.
 - В `bot/package.json` восстановлен скрипт `test` и зависимости Jest,
   благодаря чему команда `npm test --prefix bot` снова выполняет все проверки.
+- README дополнен примером домена mongodb-production-2083.up.railway.app.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
    для работы с базой **agromarket**.
    Пример строки от плагина Railway:
    `mongodb://mongo:<pass>@shinkansen.proxy.rlwy.net:<port>`
+   или `mongodb://mongo:<pass>@mongodb-production-2083.up.railway.app:27017`
    Строка подключения должна начинаться с `mongodb://` или `mongodb+srv://`,
   иначе приложение завершит запуск с ошибкой.
   `.env` не хранится в репозитории и перечислен в `.gitignore`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -308,3 +308,4 @@
 - При старте API проверяется `bot/public/index.html`. Если файла нет или он пустой,
   запускается сборка фронтенда `npm run build-client`.
 - Railway предоставляет плагин MongoDB с готовой строкой подключения.
+- В README приведён пример домена `mongodb-production-2083.up.railway.app:27017`.


### PR DESCRIPTION
## Summary
- expand example MongoDB domain for Railway

## Testing
- `npm test --prefix bot`
- `npx eslint bot/src`
- `npm run lint --prefix bot/web`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_6861775c80d08320a88cec4a075def64