### PR TITLE
Improve MongoDB connection diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,8 @@ docker compose config
 - Sidebar на десктопе можно свернуть кнопкой в узкий режим.
 - Для проверки API и БД создан скрипт `scripts/check_db_fetch.cjs`.
 - Для быстрого ping к MongoDB добавлен скрипт `scripts/check_mongo.cjs`.
+- Порт можно проверить утилитой `scripts/check_mongo_port.cjs`, а упрощённое подключение демонстрирует `scripts/simple_connect.cjs`.
+- Для оценки времени на повторы подключений используется `scripts/retry_estimate.cjs`.
 - Перед упаковкой в Docker обязательно запускайте `node scripts/check_mongo.cjs`. Скрипт работает без установленного `dotenv`, сам считывает `.env` и ищет `mongoose` в `bot/node_modules`.
 - Скрипт выводит домен и имя базы без логина и пароля, чтобы убедиться в корректности подключения.
 - При сообщении "bad auth: Authentication failed" скрипт подскажет проверить логин и пароль в `MONGO_DATABASE_URL` и предупредит, если строка подключения не содержит учётных данных.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,3 +298,5 @@
 - В файлах `bot/src/api/api.js` и `bot/src/bot/bot.js` вызов `require('dotenv').config()` загружает `.env`.
 - В README уточнена команда `npm ci --prefix bot || npm --prefix bot install`, которая автоматически собирает веб‑модуль,
   при необходимости рекомендуется повторить `npm --prefix bot/web install`.
+- Добавлена резервная строка подключения `MONGO_BACKUP_URL` и перехват события отключения в `db/connection.js`.
+- Созданы утилиты `check_mongo_port.cjs`, `simple_connect.cjs` и `retry_estimate.cjs`.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 | `BOT_TOKEN` | Токен Telegram-бота |
 | `CHAT_ID` | ID чата для уведомлений |
 | `MONGO_DATABASE_URL` | Строка подключения MongoDB |
+| `MONGO_BACKUP_URL` | Резервная строка подключения |
 | `APP_URL` | HTTPS-адрес мини‑приложения |
 | `BOT_API_URL` | URL локального сервера Bot API |
 | `WEBHOOK_URL` | Вебхук для режима webhook |
@@ -159,8 +160,10 @@
 5. Проверьте подключение к MongoDB:
    ```bash
    node scripts/check_mongo.cjs
+   node scripts/check_mongo_port.cjs
    ```
    При сообщении «bad auth: Authentication failed» убедитесь, что логин и пароль в `MONGO_DATABASE_URL` заданы верно.
+   При наличии `MONGO_BACKUP_URL` соединение переключится на резервную базу при обрыве.
 6. В переменную `CHAT_ID` запишите ID чата для уведомлений. Его можно узнать через бота `@userinfobot`.
 7. Запустите контейнеры:
 
@@ -202,6 +205,9 @@ Compose соберёт образ бота и запустит MongoDB.
 `scripts/check_mongo.cjs` проверяет доступность MongoDB. Скрипт автоматически
 читает `.env` даже без модуля `dotenv` и при отсутствии глобальной зависимости
 `mongoose` использует пакет из `bot/node_modules`.
+Для быстрой проверки порта доступен `scripts/check_mongo_port.cjs`, а самый
+краткий пример подключения показан в `scripts/simple_connect.cjs`.
+Скрипт `scripts/retry_estimate.cjs` поможет оценить время, затрачиваемое на повторные подключения.
 Перед подключением он выводит домен и имя базы без логина и пароля,
 чтобы быстро проверить корректность URL.
 Если скрипт выводит предупреждение о "bad auth: Authentication failed",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -325,3 +325,5 @@
 - Railway предоставляет плагин MongoDB с готовой строкой подключения.
 - В README приведён пример домена `mongodb-production-2083.up.railway.app:27017`.
 - Dockerfile использует рабочую директорию `/app/bot`, что уменьшает количество шагов и сокращает логи.
+- Добавлены скрипты `check_mongo_port.cjs`, `simple_connect.cjs` и `retry_estimate.cjs` для диагностики подключения.
+- В модуле `db/connection.js` реализована переподключаемость к резервной базе через `MONGO_BACKUP_URL`.

--- a/bot/src/db/connection.js
+++ b/bot/src/db/connection.js
@@ -1,12 +1,28 @@
-// Управление подключением к MongoDB с пулом соединений
+// Управление подключением к MongoDB с пулом соединений и резервным URL
 // Модули: mongoose, config
 const mongoose = require('mongoose')
 const { mongoUrl } = require('../config')
+const backupUrl = process.env.MONGO_BACKUP_URL
 
 // Для версии mongoose 8 опции useNewUrlParser и useUnifiedTopology
 // больше не требуются, оставляем только размер пула
 const opts = { maxPoolSize: 10 }
 let connecting
+
+mongoose.connection.on('disconnected', async () => {
+  console.error('Соединение с MongoDB прервано')
+  if (backupUrl && mongoUrl !== backupUrl) {
+    try {
+      await mongoose.connect(backupUrl, opts)
+      console.log('Подключились к резервной базе')
+    } catch (e) {
+      console.error('Ошибка подключения к резервной базе:', e.message)
+    }
+  }
+})
+mongoose.connection.on('error', e => {
+  console.error('Ошибка MongoDB:', e.message)
+})
 
 module.exports = async function connect() {
   if (mongoose.connection.readyState === 1) return mongoose.connection

--- a/scripts/check_mongo_port.cjs
+++ b/scripts/check_mongo_port.cjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Проверка доступности порта MongoDB и наличия переменной окружения
+require('dotenv').config()
+const net = require('net')
+
+const url = process.env.MONGO_DATABASE_URL
+if (!url) {
+  console.error('Не задана переменная MONGO_DATABASE_URL')
+  process.exit(1)
+}
+
+try {
+  const { hostname, port } = new URL(url)
+  const socket = net.connect({ host: hostname, port: Number(port) }, () => {
+    console.log(`Порт ${port} на ${hostname} открыт`)
+    socket.end()
+  })
+  socket.on('error', (err) => {
+    console.error('Ошибка соединения:', err.message)
+    process.exit(1)
+  })
+} catch (e) {
+  console.error('Ошибка разбора URL:', e.message)
+  process.exit(1)
+}

--- a/scripts/retry_estimate.cjs
+++ b/scripts/retry_estimate.cjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Оценка времени запуска с учётом повторных подключений
+const attempts = Number(process.env.RETRY_ATTEMPTS || 3)
+const delay = Number(process.env.RETRY_DELAY_MS || 5000)
+const total = attempts * delay
+console.log(`Всего ${attempts} попыток по ${delay} мс каждая.`)
+console.log(`Дополнительное время старта: ${(total / 1000).toFixed(1)} сек.`)
+console.log('Учтите, что каждое подключение создаёт новое соединение к MongoDB.')

--- a/scripts/simple_connect.cjs
+++ b/scripts/simple_connect.cjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Минимальный пример подключения к MongoDB
+require('dotenv').config()
+const { MongoClient } = require('mongodb')
+const url = process.env.MONGO_DATABASE_URL
+if (!url) {
+  console.error('Не задан MONGO_DATABASE_URL')
+  process.exit(1)
+}
+const client = new MongoClient(url)
+client.connect()
+  .then(() => {
+    console.log('Успешное подключение')
+    return client.close()
+  })
+  .catch(e => {
+    console.error('Ошибка подключения:', e.message)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary
- add MongoDB port check script and simple connect example
- provide retry estimate utility
- reconnect to backup DB when connection drops
- document new scripts and MONGO_BACKUP_URL

## Testing
- `npm test --prefix bot`
- `npx eslint bot/src`
- `npm run lint --prefix bot/web`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_b_6862ddb8652883209bb8eb44266e05f9