### PR TITLE
Fix MongoDB healthcheck

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         ports:
           - 27017:27017
         options: >-
-          --health-cmd "mongo --eval 'db.adminCommand(\"ping\")'"
+          --health-cmd "mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand(\"ping\")'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ README включает раздел о GitHub Actions и необходимос
 README дополнен описанием `BOT_API_URL` и примером локального telegram-bot-api.
 Добавлен краткий абзац о роли `BOT_API_URL` в README.
 README также показывает пример запуска `./scripts/setup_tdweb.sh` перед сборкой.
-Docker Compose содержит `healthcheck` для MongoDB, поэтому бот стартует после готовности базы.
+ Docker Compose содержит `healthcheck` для MongoDB с передачей логина и пароля `admin`/`admin`, поэтому бот стартует после готовности базы.
 Workflow `docker.yml` поднимает локальный контейнер MongoDB для проверки скриптом `check_mongo.cjs`.
 Удалены устаревшие отчёты Lighthouse, файл `extended_tailadmin_guide.md` сокращён.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
   `scripts/setup_tdweb.sh`.
 - Скрипт `create_env_from_exports.sh` теперь экранирует значения переменных, что позволяет использовать специальные символы.
 - Добавлен краткий абзац о назначении `BOT_API_URL` и локальном сервере telegram-bot-api.
-- В `docker-compose.yml` для MongoDB прописан `healthcheck`, чтобы бот запускался только после готовности базы.
+  - В `docker-compose.yml` для MongoDB прописан `healthcheck`, чтобы бот запускался только после готовности базы.
+  - В `healthcheck` добавлены логин и пароль `admin`/`admin`.
 - Удалены устаревшие отчёты Lighthouse, сокращён файл `extended_tailadmin_guide.md`.
 - Workflow `docker.yml` запускает локальный контейнер MongoDB для проверки
   соединения скриптом `check_mongo.cjs`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
    docker compose up -d
    ```
    Этот запуск поднимет и локальный MongoDB на порту 27017 с логином `admin` и паролем `admin`.
-   Сервис БД содержит `healthcheck`, поэтому бот начнёт работу только после готовности MongoDB.
+    Сервис БД содержит `healthcheck`, который выполняет `mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`, поэтому бот начнёт работу только после готовности MongoDB.
 
 5. При желании запустите локальный сервер telegram-bot-api и пропишите его адрес:
    ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,8 @@
 
 16. Краткий абзац о роли `BOT_API_URL` в README для пояснения локального API.
 17. Добавить `healthcheck` для MongoDB в `docker-compose.yml`, чтобы бот ждал готовности базы.
-18. Удалить устаревшие отчёты Lighthouse и кратко переписать `extended_tailadmin_guide.md`.
-19. В workflow `docker.yml` запускать локальный контейнер MongoDB для проверки
+18. В `healthcheck` использовать `mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`.
+19. Удалить устаревшие отчёты Lighthouse и кратко переписать `extended_tailadmin_guide.md`.
+20. В workflow `docker.yml` запускать локальный контейнер MongoDB для проверки
     соединения перед сборкой образов.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - mongo_db_example_app:/data/db
     healthcheck:
-      test: ["CMD", "mongo", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongo", "-u", "admin", "-p", "admin", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- include credentials in MongoDB healthcheck in docker-compose
- ensure GitHub Actions uses same login and password
- document the updated check in README, ROADMAP, CHANGELOG and AGENTS

## Testing
- `./scripts/setup_and_test.sh`
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_b_6865261c0a288320a434c047b0690cfe