### PR TITLE
Исправлен healthcheck MongoDB

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
         ports:
           - 27017:27017
         options: >-
-          --health-cmd "mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand(\"ping\")'"
+          --health-cmd "mongosh -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand(\"ping\")'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ README включает раздел о GitHub Actions и необходимос
 README дополнен описанием `BOT_API_URL` и примером локального telegram-bot-api.
 Добавлен краткий абзац о роли `BOT_API_URL` в README.
 README также показывает пример запуска `./scripts/setup_tdweb.sh` перед сборкой.
- Docker Compose содержит `healthcheck` для MongoDB с передачей логина и пароля `admin`/`admin`, поэтому бот стартует после готовности базы.
-Workflow `docker.yml` поднимает локальный контейнер MongoDB для проверки скриптом `check_mongo.cjs`.
+ Docker Compose содержит `healthcheck` для MongoDB с передачей логина и пароля `admin`/`admin`.
+ В нём теперь используется команда `mongosh`, что совместимо с новыми версиями образа.
+ Workflow `docker.yml` поднимает локальный контейнер MongoDB для проверки скриптом `check_mongo.cjs`.
 Удалены устаревшие отчёты Lighthouse, файл `extended_tailadmin_guide.md` сокращён.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Удалены устаревшие отчёты Lighthouse, сокращён файл `extended_tailadmin_guide.md`.
 - Workflow `docker.yml` запускает локальный контейнер MongoDB для проверки
   соединения скриптом `check_mongo.cjs`.
+- В `healthcheck` теперь используется `mongosh` вместо `mongo` для совместимости с новой версией образа MongoDB.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
    docker compose up -d
    ```
    Этот запуск поднимет и локальный MongoDB на порту 27017 с логином `admin` и паролем `admin`.
-    Сервис БД содержит `healthcheck`, который выполняет `mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`, поэтому бот начнёт работу только после готовности MongoDB.
+    Сервис БД содержит `healthcheck`, который выполняет `mongosh -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`, поэтому бот начнёт работу только после готовности MongoDB.
 
 5. При желании запустите локальный сервер telegram-bot-api и пропишите его адрес:
    ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@
 
 16. Краткий абзац о роли `BOT_API_URL` в README для пояснения локального API.
 17. Добавить `healthcheck` для MongoDB в `docker-compose.yml`, чтобы бот ждал готовности базы.
-18. В `healthcheck` использовать `mongo -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`.
+18. В `healthcheck` использовать `mongosh -u admin -p admin --authenticationDatabase admin --eval 'db.adminCommand("ping")'`.
 19. Удалить устаревшие отчёты Lighthouse и кратко переписать `extended_tailadmin_guide.md`.
 20. В workflow `docker.yml` запускать локальный контейнер MongoDB для проверки
     соединения перед сборкой образов.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - mongo_db_example_app:/data/db
     healthcheck:
-      test: ["CMD", "mongo", "-u", "admin", "-p", "admin", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongosh", "-u", "admin", "-p", "admin", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- use `mongosh` in MongoDB healthchecks
- document new command in README, ROADMAP, AGENTS
- update CHANGELOG

## Testing
- `./scripts/setup_and_test.sh`
- `docker compose config`


------
https://chatgpt.com/codex/tasks/task_b_686559ccca3c832080ed0e3548b417d2