### PR TITLE
Add docker presence warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Новый]
 - Уточнён владелец репозитория и email в SECURITY.md и CODEOWNERS
 - В `setup_and_test.sh` тесты запускаются с флагом `--detectOpenHandles`
-- Скрипт `setup_and_test.sh` проверяет `docker compose config` только при наличии команды `docker`
+- Скрипт `setup_and_test.sh` проверяет `docker compose config` только при наличии команды `docker` и выводит предупреждение, если Docker не найден
 - Добавлен скрипт `audit_deps.sh` и шаг CI для проверки зависимостей
 - На форме входа можно отправить данные клавишей Enter
 - Поле "Название" перемещено в начало формы задачи

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ npm --prefix bot run check:mongo
 ./scripts/setup_and_test.sh
 ```
 Скрипт выполняет Jest с флагом `--detectOpenHandles`, чтобы выявлять незавершённые асинхронные операции.
-При наличии установленного Docker и файла `docker-compose.yml` происходит проверка конфигурации через `docker compose config`.
+При наличии установленного Docker и файла `docker-compose.yml` происходит проверка конфигурации через `docker compose config`. Если Docker отсутствует, скрипт выводит предупреждение.
 
 ## CI/CD
 GitHub Actions используют тот же скрипт; workflow `docker.yml` поднимает MongoDB для проверки.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 1. Подготовка окружения: `.env` из `.env.example`, запуск Docker Compose
 2. Развитие бота и мини‑приложения в каталоге `bot`
-3. Автоматические тесты через `./scripts/setup_and_test.sh` локально и в CI; при наличии Docker проверяется `docker compose config`
+3. Автоматические тесты через `./scripts/setup_and_test.sh` локально и в CI; при наличии Docker проверяется `docker compose config`, иначе выводится предупреждение
 4. Аудит зависимостей командой `./scripts/audit_deps.sh`
 5. Проверка MongoDB скриптом `check_mongo.cjs`, использование healthcheck в Docker
 6. Поддержка pm2 6.0.8 и повторных подключений к базе

--- a/scripts/setup_and_test.sh
+++ b/scripts/setup_and_test.sh
@@ -19,6 +19,10 @@ npx eslint bot/src
 npm run lint --prefix bot/web
 
 # Проверяем конфигурацию docker compose при наличии команды docker
-if command -v docker >/dev/null && [ -f docker-compose.yml ]; then
-  docker compose config >/dev/null
+if command -v docker >/dev/null; then
+  if [ -f docker-compose.yml ]; then
+    docker compose config >/dev/null
+  fi
+else
+  echo "Предупреждение: Docker не найден, пропускаем проверку docker compose." >&2
 fi


### PR DESCRIPTION
## Summary
- warn if Docker is missing in `setup_and_test.sh`
- clarify Docker check in README
- update ROADMAP about setup script behaviour
- document in CHANGELOG

## Testing
- `./scripts/setup_and_test.sh`
- `./scripts/audit_deps.sh`


------
https://chatgpt.com/codex/tasks/task_b_686a80b388c483208e8ddd77d00ee00c